### PR TITLE
Read gui_groups choices from dbd

### DIFF
--- a/src/main/java/com/cosylab/vdct/dbd/DBDConstants.java
+++ b/src/main/java/com/cosylab/vdct/dbd/DBDConstants.java
@@ -59,36 +59,5 @@ public interface DBDConstants {
 	public static final int DECIMAL	= 0;
 	public static final int HEX		= 1;
 	
-
-	
-	// lower number means higer pos. in property-window
-	public static final int GUI_UNDEFINED = Integer.MAX_VALUE;
-	
-	public static final int GUI_COMMON	 =  0;
-	public static final int GUI_LINKS	 =  1;
-	public static final int GUI_INPUTS	 =  2;
-	public static final int GUI_OUTPUT	 =  3;
-	public static final int GUI_SCAN	 =  4;
-	public static final int GUI_ALARMS 	 =  5;
-	public static final int GUI_DISPLAY  =  6;
-	public static final int GUI_BITS1	 =  7;
-	public static final int GUI_BITS2 	 =  8;
-	public static final int GUI_CALC	 =  9;
-	public static final int GUI_CLOCK	 = 10;
-	public static final int GUI_COMPRESS = 11;
-	public static final int GUI_CONVERT  = 12;
-	public static final int GUI_HIST	 = 13;
-	public static final int GUI_MBB		 = 14;
-	public static final int GUI_MOTOR	 = 15;
-	public static final int GUI_PID		 = 16;
-	public static final int GUI_PULSE	 = 17;
-	public static final int GUI_SELECT	 = 18;
-	public static final int GUI_SEQ1	 = 19;
-	public static final int GUI_SEQ2	 = 20;
-	public static final int GUI_SEQ3	 = 21;
-	public static final int GUI_SUB	 	 = 22;
-	public static final int GUI_TIMER	 = 23;
-	public static final int GUI_WAVE	 = 24;
-
 	public static final char quoteChar = '"';
 }

--- a/src/main/java/com/cosylab/vdct/dbd/DBDData.java
+++ b/src/main/java/com/cosylab/vdct/dbd/DBDData.java
@@ -40,6 +40,7 @@ public class DBDData {
 	protected Hashtable records = null;
 	protected Hashtable menus = null;
 	protected Hashtable devices = null;
+	protected Map<String, DBDGuiGroupData> gui_groups = null;
 /**
  * DBDData constructor comment.
  */
@@ -47,6 +48,7 @@ public DBDData() {
 	records = new Hashtable();
 	menus = new Hashtable();
 	devices = new Hashtable();
+    gui_groups = new Hashtable<String, DBDGuiGroupData>();
 }
 /**
  * This method was created in VisualAge.
@@ -79,6 +81,20 @@ public void addRecord(DBDRecordData rd) {
 		records.put(rd.name, rd);
 	else
 		Console.getInstance().println("Record "+rd.getName()+" already exists in DBD - ignoring this definition.");
+}
+/**
+ * Find gui_group tag in global table and return index.
+ *
+ * @param tag promptgroup tag string
+ * @return gui_group data object
+ */
+public DBDGuiGroupData findOrAddGuiGroup(String tag) {
+    DBDGuiGroupData gg = gui_groups.get(tag);
+	if (gg == null) {
+        gg = new DBDGuiGroupData(tag,gui_groups.size()+1);
+		gui_groups.put(tag, gg);
+    }
+    return gg;
 }
 /**
  * This method was created in VisualAge.

--- a/src/main/java/com/cosylab/vdct/dbd/DBDFieldData.java
+++ b/src/main/java/com/cosylab/vdct/dbd/DBDFieldData.java
@@ -36,10 +36,10 @@ public class DBDFieldData {
 	private static String nullString = "";
 	
 	protected String name;	
-	protected int GUI_type = DBDConstants.GUI_UNDEFINED;
+	protected DBDGuiGroupData gui_group;
 	protected int field_type = DBDConstants.NOT_DEFINED;
 	protected String init_value = nullString;
-	protected String prompt_value = nullString; 	
+	protected String prompt_value = nullString;
 
 	// for integer fields
 	protected int base_type = DBDConstants.DECIMAL;
@@ -66,12 +66,11 @@ public int getField_type() {
 	return field_type;
 }
 /**
- * Insert the method's description here.
- * Creation date: (9.12.2000 16:25:01)
- * @return int
+ * gui_group getter.
+ * @return gui_group numerical index
  */
-public int getGUI_type() {
-	return GUI_type;
+public DBDGuiGroupData getGui_group() {
+	return gui_group;
 }
 /**
  * Insert the method's description here.
@@ -130,12 +129,11 @@ public void setField_type(int newField_type) {
 	field_type = newField_type;
 }
 /**
- * Insert the method's description here.
- * Creation date: (9.12.2000 16:25:01)
- * @param newGUI_type int
+ * Gui group setter.
+ * @param newGui_group int
  */
-public void setGUI_type(int newGUI_type) {
-	GUI_type = newGUI_type;
+public void setGui_group(DBDGuiGroupData newGui_group) {
+	gui_group = newGui_group;
 }
 /**
  * Insert the method's description here.

--- a/src/main/java/com/cosylab/vdct/dbd/DBDGuiGroupData.java
+++ b/src/main/java/com/cosylab/vdct/dbd/DBDGuiGroupData.java
@@ -1,0 +1,62 @@
+package com.cosylab.vdct.dbd;
+
+/**
+ * Copyright (c) 2002, Cosylab, Ltd., Control System Laboratory, www.cosylab.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer. Redistributions in binary
+ * form must reproduce the above copyright notice, this list of conditions and
+ * the following disclaimer in the documentation and/or other materials provided
+ * with the distribution. Neither the name of the Cosylab, Ltd., Control System
+ * Laboratory nor the names of its contributors may be used to endorse or
+ * promote products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+public class DBDGuiGroupData {
+
+    protected String tag = null;
+    protected int index = 0;
+
+    /**
+     * Constructor.
+     * @param newTag promptgroup string tag
+     * @param newIndex index value for this entry
+     */
+    public DBDGuiGroupData(String newTag, int newIndex) {
+        tag = newTag;
+        index = newIndex;
+    }
+
+    /**
+     * Getter for string tag.
+     * @return gui_group string tag
+     */
+    public String getTag() {
+        return tag;
+    }
+
+    /**
+     * Getter for index value.
+     * @return gui_group index
+     */
+    public int getIndex() {
+        return index;
+    }
+}

--- a/src/main/java/com/cosylab/vdct/dbd/DBDResolver.java
+++ b/src/main/java/com/cosylab/vdct/dbd/DBDResolver.java
@@ -134,73 +134,6 @@ public static String getFieldType(int type) {
 
 /**
  * This method was created in VisualAge.
- * @return java.lang.String
- * @param GUItype int
- */
-public static String getGUIString(int GUItype) {
-	if (GUItype==DBDConstants.GUI_COMMON) return "GUI_COMMON";
-	else if (GUItype==DBDConstants.GUI_ALARMS) return "GUI_ALARMS";
-	else if (GUItype==DBDConstants.GUI_BITS1) return "GUI_BITS1";
-	else if (GUItype==DBDConstants.GUI_BITS2) return "GUI_BITS2";
-	else if (GUItype==DBDConstants.GUI_CALC) return "GUI_CALC";
-	else if (GUItype==DBDConstants.GUI_CLOCK) return "GUI_CLOCK";
-	else if (GUItype==DBDConstants.GUI_COMPRESS) return "GUI_COMPRESS";
-	else if (GUItype==DBDConstants.GUI_CONVERT) return "GUI_CONVERT";
-	else if (GUItype==DBDConstants.GUI_DISPLAY) return "GUI_DISPLAY";
-	else if (GUItype==DBDConstants.GUI_HIST) return "GUI_HIST";
-	else if (GUItype==DBDConstants.GUI_INPUTS) return "GUI_INPUTS";
-	else if (GUItype==DBDConstants.GUI_LINKS) return "GUI_LINKS";
-	else if (GUItype==DBDConstants.GUI_MBB) return "GUI_MBB";
-	else if (GUItype==DBDConstants.GUI_MOTOR) return "GUI_MOTOR";
-	else if (GUItype==DBDConstants.GUI_OUTPUT) return "GUI_OUTPUT";
-	else if (GUItype==DBDConstants.GUI_PID) return "GUI_PID";
-	else if (GUItype==DBDConstants.GUI_PULSE) return "GUI_PULSE";
-	else if (GUItype==DBDConstants.GUI_SELECT) return "GUI_SELECT";
-	else if (GUItype==DBDConstants.GUI_SEQ1) return "GUI_SEQ1";
-	else if (GUItype==DBDConstants.GUI_SEQ2) return "GUI_SEQ2";
-	else if (GUItype==DBDConstants.GUI_SEQ3) return "GUI_SEQ3";
-	else if (GUItype==DBDConstants.GUI_SUB) return "GUI_SUB";
-	else if (GUItype==DBDConstants.GUI_TIMER) return "GUI_TIMER";
-	else if (GUItype==DBDConstants.GUI_WAVE) return "GUI_WAVE";
-	else if (GUItype==DBDConstants.GUI_SCAN) return "GUI_SCAN";
-	else return "Undefined";
-}
-/**
- * This method was created in VisualAge.
- * @return int
- * @param gui java.lang.String
- */
-public static int getGUIType(String gui) {
-	if (gui == null) return DBDConstants.GUI_UNDEFINED;
-	else if (gui.equalsIgnoreCase("GUI_COMMON")) return DBDConstants.GUI_COMMON;
-	else if (gui.equalsIgnoreCase("GUI_ALARMS")) return DBDConstants.GUI_ALARMS;
-	else if (gui.equalsIgnoreCase("GUI_BITS1")) return DBDConstants.GUI_BITS1;
-	else if (gui.equalsIgnoreCase("GUI_BITS2")) return DBDConstants.GUI_BITS2;
-	else if (gui.equalsIgnoreCase("GUI_CALC")) return DBDConstants.GUI_CALC;
-	else if (gui.equalsIgnoreCase("GUI_CLOCK")) return DBDConstants.GUI_CLOCK;
-	else if (gui.equalsIgnoreCase("GUI_COMPRESS")) return DBDConstants.GUI_COMPRESS;
-	else if (gui.equalsIgnoreCase("GUI_CONVERT")) return DBDConstants.GUI_CONVERT;
-	else if (gui.equalsIgnoreCase("GUI_DISPLAY")) return DBDConstants.GUI_DISPLAY;
-	else if (gui.equalsIgnoreCase("GUI_HIST")) return DBDConstants.GUI_HIST;
-	else if (gui.equalsIgnoreCase("GUI_INPUTS")) return DBDConstants.GUI_INPUTS;
-	else if (gui.equalsIgnoreCase("GUI_LINKS")) return DBDConstants.GUI_LINKS;
-	else if (gui.equalsIgnoreCase("GUI_MBB")) return DBDConstants.GUI_MBB;
-	else if (gui.equalsIgnoreCase("GUI_MOTOR")) return DBDConstants.GUI_MOTOR;
-	else if (gui.equalsIgnoreCase("GUI_OUTPUT")) return DBDConstants.GUI_OUTPUT;
-	else if (gui.equalsIgnoreCase("GUI_PID")) return DBDConstants.GUI_PID;
-	else if (gui.equalsIgnoreCase("GUI_PULSE")) return DBDConstants.GUI_PULSE;
-	else if (gui.equalsIgnoreCase("GUI_SELECT")) return DBDConstants.GUI_SELECT;
-	else if (gui.equalsIgnoreCase("GUI_SEQ1")) return DBDConstants.GUI_SEQ1;
-	else if (gui.equalsIgnoreCase("GUI_SEQ2")) return DBDConstants.GUI_SEQ2;
-	else if (gui.equalsIgnoreCase("GUI_SEQ3")) return DBDConstants.GUI_SEQ3;
-	else if (gui.equalsIgnoreCase("GUI_SUB")) return DBDConstants.GUI_SUB;
-	else if (gui.equalsIgnoreCase("GUI_TIMER")) return DBDConstants.GUI_TIMER;
-	else if (gui.equalsIgnoreCase("GUI_WAVE")) return DBDConstants.GUI_WAVE;
-	else if (gui.equalsIgnoreCase("GUI_SCAN")) return DBDConstants.GUI_SCAN;
-	else return DBDConstants.GUI_UNDEFINED;
-}
-/**
- * This method was created in VisualAge.
  * @return java.io.EnhancedStreamTokenizer
  * @param fileName java.lang.String
  */
@@ -272,7 +205,7 @@ public static void processDBD(DBDData data, EnhancedStreamTokenizer tokenizer, S
 						(tokenizer.ttype == DBDConstants.quoteChar)) rd.setName(tokenizer.sval);
 					else throw (new DBDParseException("Invalid record_type...", tokenizer, fileName));
 
-					processFields(rd, tokenizer, fileName, paths);
+					processFields(data, rd, tokenizer, fileName, paths);
 					data.addRecord(rd);
 				}
 				
@@ -379,7 +312,7 @@ public static void processDBD(DBDData data, EnhancedStreamTokenizer tokenizer, S
  * @param paths
  * @throws java.lang.Exception
  */
-public static void processFields(DBDRecordData rd, EnhancedStreamTokenizer tokenizer, String fileName, PathSpecification paths) throws Exception {
+public static void processFields(DBDData data, DBDRecordData rd, EnhancedStreamTokenizer tokenizer, String fileName, PathSpecification paths) throws Exception {
 
 	DBDFieldData fd;
 
@@ -449,8 +382,12 @@ public static void processFields(DBDRecordData rd, EnhancedStreamTokenizer token
 
 						else if (tokenizer.sval.equalsIgnoreCase(PROMPTGROUP)) {
 							tokenizer.nextToken();
-							if (tokenizer.ttype == EnhancedStreamTokenizer.TT_WORD) fd.setGUI_type(getGUIType(tokenizer.sval));
-							else throw (new DBDParseException("Invalid gui_gruop...", tokenizer, fileName));
+							if ((tokenizer.ttype == DBDConstants.quoteChar) ||
+								(tokenizer.ttype == EnhancedStreamTokenizer.TT_WORD)) {
+                                DBDGuiGroupData gg = data.findOrAddGuiGroup(tokenizer.sval);
+                                fd.setGui_group(gg);
+                            }
+							else throw (new DBDParseException("Invalid gui_group...", tokenizer, fileName));
 						}
 
 						else tokenizer.nextToken();			// "read"/skip data
@@ -469,7 +406,7 @@ public static void processFields(DBDRecordData rd, EnhancedStreamTokenizer token
 
 				File file = paths.search4File(include_filename);
 				inctokenizer = getEnhancedStreamTokenizer(file.getAbsolutePath());
-				if (inctokenizer!=null) processFields(rd, inctokenizer, include_filename, new PathSpecification(file.getParentFile().getAbsolutePath(), paths));
+				if (inctokenizer!=null) processFields(data, rd, inctokenizer, include_filename, new PathSpecification(file.getParentFile().getAbsolutePath(), paths));
 
 			}	
 						

--- a/src/main/java/com/cosylab/vdct/graphics/objects/LinkManagerObject.java
+++ b/src/main/java/com/cosylab/vdct/graphics/objects/LinkManagerObject.java
@@ -694,9 +694,7 @@ public Vector getLinkMenus(Enumeration vdbFields) {
 					default:
 
 						 // no not add fields with undefined GUI type
-						 // DBD VAL promptgroup workaround
-						 if (!portOrTemplateMacro2All &&
-						 	(field.getGUI_type() == DBDConstants.GUI_UNDEFINED && !field.getName().equals("VAL")))
+						 if (!portOrTemplateMacro2All && field.getGui_group() != null)
 						 	break;
 
 						 menuitem = new JMenuItem(field.getName());

--- a/src/main/java/com/cosylab/vdct/vdb/FieldInfoProperty.java
+++ b/src/main/java/com/cosylab/vdct/vdb/FieldInfoProperty.java
@@ -192,7 +192,10 @@ public String checkValueValidity(String value) {
  * @see com.cosylab.vdct.inspector.InspectableProperty#getGuiGroup()
  */
 public Integer getGuiGroup() {
-	return new Integer(field.getGui_group().getIndex());
+    if (field.getGui_group() != null)
+        return field.getGui_group().getIndex();
+    else
+        return 0;
 }
 
 }

--- a/src/main/java/com/cosylab/vdct/vdb/FieldInfoProperty.java
+++ b/src/main/java/com/cosylab/vdct/vdb/FieldInfoProperty.java
@@ -192,7 +192,7 @@ public String checkValueValidity(String value) {
  * @see com.cosylab.vdct.inspector.InspectableProperty#getGuiGroup()
  */
 public Integer getGuiGroup() {
-	return new Integer(field.getGUI_type());
+	return new Integer(field.getGui_group().getIndex());
 }
 
 }

--- a/src/main/java/com/cosylab/vdct/vdb/VDBData.java
+++ b/src/main/java/com/cosylab/vdct/vdb/VDBData.java
@@ -158,7 +158,7 @@ public static void copyVDBFieldData(VDBFieldData sourceField, VDBFieldData targe
 	targetField.setName(sourceField.getName());
 	targetField.setValueSilently(sourceField.getValue());
 	targetField.setInit_value(sourceField.getInit_value());
-	targetField.setGUI_type(sourceField.getGUI_type());
+	targetField.setGui_group(sourceField.getGui_group());
 	targetField.setDbdData(sourceField.getDbdData());
 	targetField.setVisibility(sourceField.getVisibility());
 }
@@ -528,7 +528,7 @@ public static VDBFieldData generateVDBFieldData(Object dsId, DBDData dbd, DBReco
 	vdbField.setName(dbdField.getName());
 	vdbField.setValue(dbdField.getInit_value());
 	vdbField.setInit_value(dbdField.getInit_value());
-	vdbField.setGUI_type(dbdField.getGUI_type());
+	vdbField.setGui_group(dbdField.getGui_group());
 	vdbField.setDbdData(dbdField);
 
 	if (dbRecord!=null) {

--- a/src/main/java/com/cosylab/vdct/vdb/VDBFieldData.java
+++ b/src/main/java/com/cosylab/vdct/vdb/VDBFieldData.java
@@ -590,7 +590,10 @@ public String checkValueValidity(String value) {
  * @see com.cosylab.vdct.inspector.InspectableProperty#getGuiGroup()
  */
 public Integer getGuiGroup() {
-    return new Integer(dbdData.getGui_group().getIndex());
+    if (dbdData.getGui_group() != null)
+        return dbdData.getGui_group().getIndex();
+    else
+        return 0;
 }
 
 private Pattern getPattern()

--- a/src/main/java/com/cosylab/vdct/vdb/VDBFieldData.java
+++ b/src/main/java/com/cosylab/vdct/vdb/VDBFieldData.java
@@ -14,6 +14,7 @@ import com.cosylab.vdct.dbd.DBDConstants;
 import com.cosylab.vdct.dbd.DBDData;
 import com.cosylab.vdct.dbd.DBDDeviceData;
 import com.cosylab.vdct.dbd.DBDFieldData;
+import com.cosylab.vdct.dbd.DBDGuiGroupData;
 import com.cosylab.vdct.dbd.DBDMenuData;
 import com.cosylab.vdct.dbd.DBDResolver;
 import com.cosylab.vdct.graphics.objects.Debuggable;
@@ -60,7 +61,7 @@ import com.cosylab.vdct.util.StringUtils;
  */
 public class VDBFieldData implements InspectableProperty, Debuggable, ChangableVisibility, LinkSource {
 	protected int type;
-	protected int GUI_type;
+	protected DBDGuiGroupData gui_group;
 	protected String name;
 	protected String value;
 	protected String init_value;
@@ -126,8 +127,8 @@ public String getFullName() {
  * Creation date: (9.12.2000 18:11:46)
  * @return int
  */
-public int getGUI_type() {
-	return GUI_type;
+public DBDGuiGroupData getGui_group() {
+	return gui_group;
 }
 /**
  * Insert the method's description here.
@@ -345,10 +346,10 @@ public void setDebugValue(String newValue, Date timeStamp, short severity)
 /**
  * Insert the method's description here.
  * Creation date: (9.12.2000 18:11:46)
- * @param newGUI_type int
+ * @param newGui_group String
  */
-public void setGUI_type(int newGUI_type) {
-	GUI_type = newGUI_type;
+public void setGui_group(DBDGuiGroupData newGui_group) {
+	gui_group = newGui_group;
 }
 /**
  * Insert the method's description here.
@@ -589,7 +590,7 @@ public String checkValueValidity(String value) {
  * @see com.cosylab.vdct.inspector.InspectableProperty#getGuiGroup()
  */
 public Integer getGuiGroup() {
-	return new Integer(getGUI_type());
+    return new Integer(dbdData.getGui_group().getIndex());
 }
 
 private Pattern getPattern()


### PR DESCRIPTION
This removes the hard-coded promptgroup (gui_group) choices, replacing them with reading the choices that are used in the DBDs while scanning.
These changes are required for working with the [new promptgroup implementation](https://code.launchpad.net/~epics-core/epics-base/new-promptgroups) introduced in Base 3.15.4.

The map of choices is part of the DBD Data object, so that the map disappears when the DBD is managed away.
The only difference when using the new VDCT with old EPICS Base DBDs is that the ordering of the GUI_XXX groups is now alphabetically, where is used to be fixed based on the order of the hard-coded choices.
